### PR TITLE
Integrate error page

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,5 +1,6 @@
 ---
 Name: sharedraftcontent
+After: framework/routes#coreroutes
 ---
 SiteTree:
   extensions:
@@ -10,4 +11,7 @@ CMSMain:
 CMSPageEditController:
   extensions:
     - ShareDraftContentCMSPageEditControllerExtension
+Director:
+  rules:
+    'preview': 'ShareDraftController'
 ---

--- a/code/controllers/ShareDraftController.php
+++ b/code/controllers/ShareDraftController.php
@@ -1,0 +1,24 @@
+<?php
+
+class ShareDraftController extends Controller {
+
+	private static $allowed_actions = array(
+		'preview'
+	);
+
+	private static $url_handlers = array(
+		'$Key/$Token' => 'preview'
+	);
+
+	public function preview() {
+		// TODO: Add the actual check.
+		$tokenExpired = false;
+
+		if (!$tokenExpired) {
+			// Show the draft content.
+			return $this->render();
+		} else {
+			return $this->renderWith('ShareDraftContentError');
+		}
+	}
+}

--- a/templates/ShareDraftContentError.ss
+++ b/templates/ShareDraftContentError.ss
@@ -7,7 +7,7 @@
 		<meta name="description" content="">
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 
-		<link rel="stylesheet" href="sharedraftcontent/css/main.css">
+		<link rel="stylesheet" href="/sharedraftcontent/css/main.css">
 	</head>
 	<body id="share-draft-error-page">
 		<div class="message">


### PR DESCRIPTION
Add a controller for handling requests to preview content. The custom 404 page is displayed if the token has expired.