### PR TITLE
Fixed tests

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,3 +1,3 @@
 <?php
 
-define('SHAREDDRAFTCONTENT_DIR', basename(__DIR__));
+define('SHAREDRAFTCONTENT_DIR', basename(__DIR__));

--- a/code/controllers/ShareDraftController.php
+++ b/code/controllers/ShareDraftController.php
@@ -49,7 +49,7 @@ class ShareDraftController extends Controller {
 		$controller = $this->getControllerFor($latest);
 
 		if(!$shareToken->isExpired() && $page->generateKey($shareToken->Token) === $key) {
-			Requirements::css(SHAREDDRAFTCONTENT_DIR . '/css/top-bar.css');
+			Requirements::css(SHAREDRAFTCONTENT_DIR . '/css/top-bar.css');
 
 			$rendered = $controller->render();
 
@@ -70,7 +70,7 @@ class ShareDraftController extends Controller {
 	 * @return HTMLText
 	 */
 	protected function errorPage() {
-		Requirements::css(SHAREDDRAFTCONTENT_DIR . '/css/error-page.css');
+		Requirements::css(SHAREDRAFTCONTENT_DIR . '/css/error-page.css');
 
 		return $this->renderWith('ShareDraftContentError');
 	}

--- a/code/extensions/ShareDraftContentRequirementsExtension.php
+++ b/code/extensions/ShareDraftContentRequirementsExtension.php
@@ -2,7 +2,7 @@
 
 class ShareDraftContentRequirementsExtension extends DataExtension {
 	public function init() {
-		Requirements::css(SHAREDDRAFTCONTENT_DIR . '/css/share-component.css');
-		Requirements::javascript(SHAREDDRAFTCONTENT_DIR . '/javascript/main.js');
+		Requirements::css(SHAREDRAFTCONTENT_DIR . '/css/share-component.css');
+		Requirements::javascript(SHAREDRAFTCONTENT_DIR . '/javascript/main.js');
 	}
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
 	"require": {
 		"php": ">=5.3.2",
 		"silverstripe/framework": "~3.1",
+		"silverstripe/cms": "~3.1",
 		"assertchris/hash-compat": "~1.0"
 	},
 	"require-dev": {

--- a/tests/ShareDraftContentSiteTreeExtensionTest.php
+++ b/tests/ShareDraftContentSiteTreeExtensionTest.php
@@ -17,8 +17,12 @@ class ShareDraftContentSiteTreeExtensionTest extends FunctionalTest {
 		 * these values are not the same.
 		 */
 
+		require_once(__DIR__ . "/../_config.php");
+
+		Page::add_extension('ShareDraftContentSiteTreeExtension');
+
 		/**
-		 * @var page $firstSharedPage
+		 * @var Page $firstSharedPage
 		 */
 		$firstSharedPage = $this->objFromFixture('Page', 'FirstSharedPage');
 

--- a/tests/ShareDraftContentSiteTreeExtensionTest.yml
+++ b/tests/ShareDraftContentSiteTreeExtensionTest.yml
@@ -2,4 +2,4 @@ Page:
   FirstSharedPage:
     Name: 'First Shared Page'
   SecondSharedPage:
-      Name: 'Second Shared Page'
+    Name: 'Second Shared Page'


### PR DESCRIPTION
The tests were passing, when the module was made, because it was already enabled. If it's not enabled (in config) then the tests wouldn't pass because required config wasn't yet included. This PR makes the tests include these config things before making any assertions about the functionality of the extended SiteTree objects.