### PR TITLE
Fix preview icons for 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,23 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
-    - 7.0
+  - 5.3
+  - 5.4
+  - 7.0
 
 sudo: false
 
 env:
-  - DB=MYSQL CORE_RELEASE=3.1
+  - DB=MYSQL CORE_RELEASE=3.3
 
 matrix:
   include:
     - php: 5.5
       env: DB=PGSQL CORE_RELEASE=3
     - php: 5.6
-      env: DB=MYSQL CORE_RELEASE=3.2
+      env: DB=MYSQL CORE_RELEASE=3.3
+  allow_failures:
+    - php: 7.0
 
 before_script:
   - composer self-update || true
@@ -25,16 +27,12 @@ before_script:
   - composer install
 
 script:
-    - vendor/bin/phpunit --coverage-clover coverage.clover sharedraftcontent/tests
-    - wget https://scrutinizer-ci.com/ocular.phar
-    - git remote rm origin
-    - git remote add origin git@github.com:silverstripe-labs/silverstripe-sharedraftcontent.git
-    - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - vendor/bin/phpunit --coverage-clover coverage.clover sharedraftcontent/tests
+  - wget https://scrutinizer-ci.com/ocular.phar
+  - git remote rm origin
+  - git remote add origin git@github.com:silverstripe-labs/silverstripe-sharedraftcontent.git
+  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 
 branches:
-    only:
-        - master
-
-matrix:
-    allow_failures:
-        - php: 7.0
+  only:
+    - master

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
 		}
 	],
 	"require": {
-		"silverstripe/framework": "~3.1",
-		"silverstripe/cms": "~3.1",
+		"silverstripe/framework": "~3.3",
+		"silverstripe/cms": "~3.3",
 		"assertchris/hash-compat": "~1.0"
 	},
 	"require-dev": {

--- a/templates/Includes/LeftAndMain_ViewModeSelector.ss
+++ b/templates/Includes/LeftAndMain_ViewModeSelector.ss
@@ -1,12 +1,12 @@
 <span id="$SelectID" class="preview-mode-selector preview-selector field dropdown">
-	<select title="<% _t('SilverStripeNavigator.ChangeViewMode', 'Change view mode') %>" id="$SelectID-select" class="preview-dropdown dropdown nolabel no-change-track" autocomplete="off" name="Action">
+	<select title="<%t SilverStripeNavigator.ChangeViewMode 'Change view mode' %>" id="$SelectID-select" class="preview-dropdown dropdown nolabel no-change-track" autocomplete="off" name="Action">
 
-		<option data-icon="icon-split" class="icon-split icon-view first" value="split"><% _t('SilverStripeNavigator.SplitView', 'Split mode') %></option>
-		<option data-icon="icon-preview" class="icon-preview icon-view" value="preview"><% _t('SilverStripeNavigator.PreviewView', 'Preview mode') %></option>
-		<option data-icon="icon-edit" class="icon-edit icon-view last" value="content"><% _t('SilverStripeNavigator.EditView', 'Edit mode') %></option>
+		<option data-icon="font-icon-columns" class="font-icon-columns icon-view first" value="split"><%t SilverStripeNavigator.SplitView 'Split mode' %></option>
+		<option data-icon="font-icon-eye" class="font-icon-eye icon-view" value="preview"><%t SilverStripeNavigator.PreviewView 'Preview mode' %></option>
+		<option data-icon="font-icon-edit-write" class="font-icon-edit-write icon-view last" value="content"><%t SilverStripeNavigator.EditView 'Edit mode' %></option>
 		<!-- Dual window not implemented yet -->
 		<!--
-			<option data-icon="icon-window" class="icon-window icon-view last" value="window"><% _t('SilverStripeNavigator.DualWindowView', 'Dual Window') %></option>
+			<option data-icon="icon-window" class="icon-window icon-view last" value="window"><%t SilverStripeNavigator.DualWindowView 'Dual Window' %></option>
 		-->
 	</select>
 


### PR DESCRIPTION
Fix for the preview icons not showing (https://github.com/silverstripe-labs/silverstripe-sharedraftcontent/issues/52)

This fix for 3.3 will break the icons for 3.2/3.1 in the same way, so a new branch may need to be made before this is merged.