### PR TITLE
BUG Fix home page blank on preview

### DIFF
--- a/code/controllers/ShareDraftController.php
+++ b/code/controllers/ShareDraftController.php
@@ -70,7 +70,10 @@ class ShareDraftController extends Controller
                 Session::set('unsecuredDraftSite', true);
                 Versioned::reading_stage('Stage');
 
-                // Create mock request; Simplify request to single top level reqest
+                // Hack to get around ContentController::init() redirecting on home page
+                $_FILES = array(array());
+
+                // Create mock request; Simplify request to single top level request
                 $pageRequest = new SS_HTTPRequest('GET', $page->URLSegment);
                 $pageRequest->match('$URLSegment//$Action/$ID/$OtherID', true);
                 $rendered = $controller->handleRequest($pageRequest, $this->model);
@@ -110,14 +113,6 @@ class ShareDraftController extends Controller
      */
     protected function getControllerFor($page)
     {
-        $config = Config::inst()->forClass('ShareDraftController');
-
-        $controller = $config->controller;
-
-        if (!$controller || !class_exists($controller)) {
-            return new ContentController($page);
-        }
-
-        return new $controller($page);
+        return ModelAsController::controller_for($page);
     }
 }


### PR DESCRIPTION
Fixes #58

This is a hack to work around the fact that RootURLController has a $is_at_root that we need to, but can't set, to true, when mocking a home page route.