### PR TITLE
Update RemoveExpiredShareTokens class name for Composer 2.0

### DIFF
--- a/src/Tasks/RemoveExpiredShareTokensTask.php
+++ b/src/Tasks/RemoveExpiredShareTokensTask.php
@@ -12,7 +12,7 @@ use SilverStripe\ShareDraftContent\Models\ShareToken;
  *
  * To run this action the user needs admin rights.
  */
-class RemoveExpiredShareTokens extends BuildTask
+class RemoveExpiredShareTokensTask extends BuildTask
 {
     private static $segment = 'RemoveExpiredShareTokens';
 


### PR DESCRIPTION
This should fix #127 setting the class name to be the same as the file name