### PR TITLE
Handle Redirects within a page (e.g. root redirects onto an action)

### DIFF
--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -8,7 +8,9 @@ use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\CMS\Controllers\ModelAsController;
 use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Control\Controller;
+use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
+use SilverStripe\Control\HTTPRequestBuilder;
 use SilverStripe\Control\Middleware\HTTPCacheControlMiddleware;
 use SilverStripe\Control\Session;
 use SilverStripe\Core\Injector\Injector;
@@ -79,8 +81,6 @@ class ShareDraftController extends Controller
 
         $latest = Versioned::get_latest_version(SiteTree::class, $shareToken->PageID);
 
-        $controller = $this->getControllerFor($page);
-
         if (!$shareToken->isExpired() && $page->generateKey($shareToken->Token) === $key) {
             Requirements::css('silverstripe/sharedraftcontent: client/dist/styles/bundle-frontend.css');
 
@@ -93,14 +93,7 @@ class ShareDraftController extends Controller
                 $this->setIsDraftSecured($session, false);
                 Versioned::set_stage('Stage');
 
-                // Hack to get around ContentController::init() redirecting on home page
-                $_FILES = array(array());
-
-                // Create mock request; Simplify request to single top level request
-                $pageRequest = new HTTPRequest('GET', $page->URLSegment);
-                $pageRequest->match('$URLSegment//$Action/$ID/$OtherID', true);
-                $pageRequest->setSession($session);
-                $rendered = $controller->handleRequest($pageRequest);
+                $rendered = $this->getRenderedPageByURLSegment($page->URLSegment, $session);
 
                 // Render draft heading
                 $data = new ArrayData(array(
@@ -120,21 +113,32 @@ class ShareDraftController extends Controller
     }
 
     /**
+     * @param string $url
+     *
+     * @return HTTPResponse
+     */
+    protected function getRenderedPageByURLSegment($url)
+    {
+        $pageRequest = HTTPRequestBuilder::createFromEnvironment();
+        $pageRequest->setHttpMethod('GET');
+        $pageRequest->setUrl($url);
+
+        $response = Director::singleton()->handleRequest($pageRequest);
+        if ($response->isRedirect()) {
+            // The redirect will probably be Absolute URL so just want the path
+            $newUrl = parse_url($response->getHeader('location'), PHP_URL_PATH);
+            return $this->getRenderedPageByURLSegment($newUrl);
+        }
+        return $response;
+    }
+
+    /**
      * @return DBHTMLText
      */
     protected function errorPage()
     {
         Requirements::css('silverstripe/sharedraftcontent: client/dist/styles/bundle-frontend.css');
         return $this->renderWith('ShareDraftContentError');
-    }
-
-    /**
-     * @param SiteTree $page
-     * @return ContentController
-     */
-    protected function getControllerFor($page)
-    {
-        return ModelAsController::controller_for($page);
     }
 
     /**

--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -86,14 +86,14 @@ class ShareDraftController extends Controller
 
             // Temporarily un-secure the draft site and switch to draft
             $oldSecured = $this->getIsDraftSecured($session);
-            $oldMode = Versioned::get_reading_mode();
+            $oldMode = Versioned::get_default_reading_mode();
 
             // Process page inside an unsecured draft container
             try {
                 $this->setIsDraftSecured($session, false);
-                Versioned::set_stage('Stage');
+                Versioned::set_default_reading_mode('Stage.Stage');
 
-                $rendered = $this->getRenderedPageByURLSegment($page->URLSegment, $session);
+                $rendered = $this->getRenderedPageByURLSegment($page->URLSegment);
 
                 // Render draft heading
                 $data = new ArrayData(array(
@@ -103,7 +103,7 @@ class ShareDraftController extends Controller
                 $include = (string) $data->renderWith('Includes/TopBar');
             } finally {
                 $this->setIsDraftSecured($session, $oldSecured);
-                Versioned::set_reading_mode($oldMode);
+                Versioned::set_default_reading_mode($oldMode);
             }
 
             return str_replace('</body>', $include . '</body>', (string) $rendered->getBody());

--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -103,6 +103,8 @@ class ShareDraftController extends Controller
                 $include = (string) $data->renderWith('Includes/TopBar');
             } finally {
                 $this->setIsDraftSecured($session, $oldSecured);
+                // Use set_default_reading_mode() instead of set_reading_mode() because that's
+                // what's used in Versioned::choose_site_stage()
                 Versioned::set_default_reading_mode($oldMode);
             }
 


### PR DESCRIPTION
This also uses the main `Director::handleRequest()` so ALL routes are handled correctly
Changes the `Versioned::set_reading_mode()` to `Versioned::set_default_reading_mode()` as is not reset on the `Director::handleRequest()`