### PR TITLE
FIX add user agent str to indicate request is internal

### DIFF
--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -157,6 +157,8 @@ class ShareDraftController extends Controller
         $variables = HTTPRequestBuilder::cleanEnvironment(Environment::getVariables());
         $variables['_SERVER']['REQUEST_URI'] = $url;
         $variables['_SERVER']['REQUEST_METHOD'] = 'GET';
+        $variables['_SERVER']['HTTP_USER_AGENT'] = 'CLI';
+
         Environment::setVariables($variables);
 
         // Health-check prior to creating environment


### PR DESCRIPTION
Relates to an issue when using this functionality in combination with other middleware (in our case axllent/silverstripe-trailing-slash). 