### PR TITLE
Remove `$` from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ releases exist for earlier Silverstripe 4.x versions.
 The easiest way to install is by using [Composer](https://getcomposer.org):
 
 ```sh
-$ composer require silverstripe/sharedraftcontent
+composer require silverstripe/sharedraftcontent
 ```
 
 You'll also need to run `dev/build`. You should now see a link/button on the bottom-right of edit pages. Clicking the link will generate a new share link.


### PR DESCRIPTION
Github now provides a copy to clipboard button, so adding the `$` prefix is counter-productive for people wanting to copy/paste the install command.