### PR TITLE
Bugfix: Infinite recursion sanity checks with more helpful error messages

### DIFF
--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -203,7 +203,7 @@ class ShareDraftController extends Controller
         return $response;
     }
 
-    private function getRedirectRecursionIterationsLog(string $appendUrl= ''): string
+    private function getRedirectRecursionIterationsLog(string $appendUrl = ''): string
     {
         return "\n\nRedirected URLs stack: \n"
             . implode("\n", $this->redirectRecursionIterations)

--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -52,10 +52,7 @@ class ShareDraftController extends Controller
      */
     protected static $isViewingPreview = false;
 
-    /**
-     * @var array
-     */
-    private $redirectRecursionIterations = [];
+    private array $redirectRecursionIterations = [];
 
     /**
      * @return bool
@@ -189,12 +186,12 @@ class ShareDraftController extends Controller
 
         if ($response->isRedirect()) {
             if (in_array($url, $this->redirectRecursionIterations)) {
-                throw new \Exception("Infinite recursion detected.".$this->getRedirectRecursionIterationsLog($url));
+                throw new \Exception("Infinite recursion detected." . $this->getRedirectRecursionIterationsLog($url));
             }
 
             $this->redirectRecursionIterations[] = $url;
             if (count($this->redirectRecursionIterations) >= 30) {
-                throw new \Exception("Max redirect recursions reached.".$this->getRedirectRecursionIterationsLog());
+                throw new \Exception("Max redirect recursions reached." . $this->getRedirectRecursionIterationsLog());
             }
 
             // The redirect will probably be Absolute URL so just want the path
@@ -206,15 +203,11 @@ class ShareDraftController extends Controller
         return $response;
     }
 
-    /**
-     * @param string $append_url
-     * @return string
-     */
-    protected function getRedirectRecursionIterationsLog(string $append_url=''): string
+    private function getRedirectRecursionIterationsLog(string $appendUrl= ''): string
     {
         return "\n\nRedirected URLs stack: \n"
             . implode("\n", $this->redirectRecursionIterations)
-            . ($append_url ? "\n$append_url" : '');
+            . ($appendUrl ? "\n$appendUrl" : '');
     }
 
     /**


### PR DESCRIPTION
Issue https://github.com/silverstripe/silverstripe-sharedraftcontent/issues/213

The following snippet in `ShareDraftController.php` at L161 includes no sanity checks to prevent infinite recursions when it attempts to follow redirects internally via recursions.

https://github.com/silverstripe/silverstripe-sharedraftcontent/blob/7c3f7e7f75883d1d7790bdd2e6a646a86901e5e4/src/Controllers/ShareDraftController.php#L137-L165

Infinite recursions, such as those experienced in #213, would previously cause fatal time out or memory limit errors.

This pull request resolves this problem by adding sanity checks, preventing unanticipated internal infinite recursions via "logging" a minimal redirect stack to a private array on `ShareDraftController` and throws an Exception (with helpful information for developers) if....
1. ...a URL has already been processed for redirection (infinite recursion detected), OR
2. ...30 redirects have been logged 
  _(30 is an arbitrary number that seems to be more than what is typically necessary; this could, in a separate PR, be pulled into a config variable if desired)_

## Examples of Exception outputs

### Infinite recursion detected
![Screenshot from 2023-10-14 15-10-05](https://github.com/silverstripe/silverstripe-sharedraftcontent/assets/323945/6f9da94d-f423-45f3-9b59-18d709437244)

### Max redirect recursions reached
![Screenshot from 2023-10-14 15-09-30](https://github.com/silverstripe/silverstripe-sharedraftcontent/assets/323945/bb1c85e2-5084-45d0-acc6-64d45fccc8e3)


## Related 
- #213 

## Info

- Edits for maintainers are enabled 
- Set to merge into `2` and can be rebased onto `3` without issue

---
@muskie9
