### PR TITLE
FIX Update CMS fields now that they're being scaffolded

### DIFF
--- a/src/Extensions/ShareDraftContentSiteTreeExtension.php
+++ b/src/Extensions/ShareDraftContentSiteTreeExtension.php
@@ -43,6 +43,15 @@ class ShareDraftContentSiteTreeExtension extends DataExtension
         'ShareTokens' => ShareToken::class,
     );
 
+    private static array $scaffold_cms_fields_settings = [
+        'ignoreFields' => [
+            'ShareTokenSalt',
+        ],
+        'ignoreRelations' => [
+            'ShareTokens',
+        ],
+    ];
+
     /**
      * @var array
      */


### PR DESCRIPTION
Relies on changes to `SiteTree` in https://github.com/silverstripe/silverstripe-cms/pull/2983


## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2767