### PR TITLE
Allow users to share draft files to non members

### DIFF
--- a/_config/config.yml
+++ b/_config/config.yml
@@ -2,6 +2,9 @@
 Name: sharedraftcontent
 After: framework/routes#coreroutes
 ---
+SilverStripe\Assets\File:
+  extensions:
+    - SilverStripe\ShareDraftContent\Extensions\ShareDraftContentSiteTreeExtension
 SilverStripe\CMS\Model\SiteTree:
   extensions:
     - SilverStripe\ShareDraftContent\Extensions\ShareDraftContentSiteTreeExtension

--- a/src/Models/ShareToken.php
+++ b/src/Models/ShareToken.php
@@ -3,6 +3,7 @@
 namespace SilverStripe\ShareDraftContent\Models;
 
 use Page;
+use SilverStripe\Assets\File;
 use SilverStripe\ORM\DataObject;
 use SilverStripe\ORM\FieldType\DBDatetime;
 
@@ -26,7 +27,8 @@ class ShareToken extends DataObject
      * @var array
      */
     private static $has_one = array(
-        'Page' => Page::class
+        'Page' => Page::class,
+        'File' => File::class,
     );
 
     /**


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Allow sharing draft assets using this module
<!--
  Please describe expected and observed behaviour, and what you're fixing.
  For visual fixes, please include tested browsers and screenshots.
-->

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
[249](https://github.com/silverstripe/silverstripe-sharedraftcontent/issues/249)

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
