### PR TITLE
FIX Don't rely on session for current record ID

### DIFF
--- a/src/Extensions/ShareDraftContentControllerExtension.php
+++ b/src/Extensions/ShareDraftContentControllerExtension.php
@@ -53,9 +53,27 @@ class ShareDraftContentControllerExtension extends Extension
      */
     public function getShareDraftLinkAction()
     {
-        if ($this->owner->config()->get('url_segment')) {
-            return $this->owner->Link('MakeShareDraftLink');
+        $owner = $this->getOwner();
+        if (!$owner->config()->get('url_segment')) {
+            return '';
         }
-        return '';
+        $id = $this->getRecordID();
+        if (!$id) {
+            return '';
+        }
+        return $owner->Link(Controller::join_links('MakeShareDraftLink', $id));
+    }
+
+    private function getRecordID(): ?int
+    {
+        $owner = $this->getOwner();
+        if ($owner->hasMethod('currentRecordID')) {
+            return $owner->currentRecordID();
+        }
+        // Could be a non-LeftAndMain controller, since the extension is applied directly to Controller
+        if ($owner->hasMethod('CurrentPage')) {
+            return $owner->CurrentPage()?->ID;
+        }
+        return null;
     }
 }


### PR DESCRIPTION
Storing the current record ID in the session was deprecated, and is being removed in https://github.com/silverstripe/silverstripe-admin/pull/1867

We now need to make sure the ID is included in the URL for making the share draft link, so we know what record we're making a link for.

This is covered by behat tests already.

## Issue
- https://github.com/silverstripe/silverstripe-cms/issues/2947