### PR TITLE
FIX Check Page exist before generation of key

### DIFF
--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -91,10 +91,6 @@ class ShareDraftController extends Controller
         $page = Versioned::get_by_stage(SiteTree::class, Versioned::DRAFT)
             ->byID($shareToken->PageID);
 
-        if (!$page) {
-            return $this->errorPage();
-        }
-
         $this->extend('updatePage', $page);
 
         if (!$page) {

--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -93,6 +93,10 @@ class ShareDraftController extends Controller
 
         $this->extend('updatePage', $page);
 
+        if (!$page) {
+            return $this->errorPage();
+        }
+
         $latest = Versioned::get_latest_version(SiteTree::class, $shareToken->PageID);
 
         if (!$shareToken->isExpired() && $page->generateKey($shareToken->Token) === $key) {

--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -91,6 +91,10 @@ class ShareDraftController extends Controller
         $page = Versioned::get_by_stage(SiteTree::class, Versioned::DRAFT)
             ->byID($shareToken->PageID);
 
+        if (!$page) {
+            return $this->errorPage();
+        }
+
         $this->extend('updatePage', $page);
 
         if (!$page) {


### PR DESCRIPTION
<!--
  Thanks for contributing, you're awesome! ⭐

  Please read https://docs.silverstripe.org/en/contributing/code/ if you haven't contributed to this project recently.
-->
## Description
Fix the behavior when accessing a page through shareable link which is not present

## Manual testing steps
<!--
  Include any manual testing steps here which a reviewer can perform to validate your pull request works correctly.
  Note that this DOES NOT replace unit or end-to-end tests.
-->

## Issues
<!--
  List all issues here that this pull request fixes/resolves.
  If there is no issue already, create a new one! You must link your pull request to at least one issue.
-->
- https://github.com/silverstripe/silverstripe-sharedraftcontent/issues/280
#

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [x] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
