### PR TITLE
ENH Add index for share draft token

### DIFF
--- a/src/Models/ShareToken.php
+++ b/src/Models/ShareToken.php
@@ -29,6 +29,10 @@ class ShareToken extends DataObject
         'Page' => Page::class
     );
 
+    private static array $indexes = [
+        'Token' => true,
+    ];
+
     /**
      * @var string
      */


### PR DESCRIPTION
`Token` is used to find `ShareToken` records - see `ShareDraftController::preview()`.
It's also used to check for duplicates in `ShareDraftContentSiteTreeExtension::getNewShareToken()`.

## Issue

- https://github.com/silverstripe/.github/issues/414