### PR TITLE
Preserve and restore Versioned stage when rendering shared draft previews

### DIFF
--- a/src/Controllers/ShareDraftController.php
+++ b/src/Controllers/ShareDraftController.php
@@ -103,28 +103,42 @@ class ShareDraftController extends Controller
             Requirements::css('silverstripe/sharedraftcontent: client/dist/styles/bundle-frontend.css');
 
             // Temporarily un-secure the draft site and switch to draft
-            $oldSecured = $this->getIsDraftSecured($session);
-            $oldMode = Versioned::get_default_reading_mode();
+            $oldDraftSecured = $this->getIsDraftSecured($session);
+
+            $oldDefaultReadingMode = Versioned::get_default_reading_mode();
+            $oldReadingMode = Versioned::get_reading_mode();
+            $oldStage = Versioned::get_stage();
+
             static::$isViewingPreview = true;
 
-            // Process page inside an unsecured draft container
             try {
+                // Temporarily unsecure the draft site and switch to Draft
                 $this->setIsDraftSecured($session, false);
-                Versioned::set_default_reading_mode('Stage.Stage');
+                Versioned::set_default_reading_mode('Stage.' . Versioned::DRAFT);
+                Versioned::set_reading_mode('Stage.' . Versioned::DRAFT);
+                Versioned::set_stage(Versioned::DRAFT);
 
                 $rendered = $this->getRenderedPageByURL($page->Link());
 
-                // Render draft heading
-                $data = new ArrayData(array(
+                $data = new ArrayData([
                     'Page' => $page,
                     'Latest' => $latest,
-                ));
+                ]);
+
                 $include = (string) $data->renderWith('Includes/TopBar');
             } finally {
-                $this->setIsDraftSecured($session, $oldSecured);
-                // Use set_default_reading_mode() instead of set_reading_mode() because that's
-                // what's used in Versioned::choose_site_stage()
-                Versioned::set_default_reading_mode($oldMode);
+                // Restore original draft security, stage and reading mode
+                $this->setIsDraftSecured($session, $oldDraftSecured);
+
+                if ($oldReadingMode) {
+                    Versioned::set_default_reading_mode($oldDefaultReadingMode);
+                    Versioned::set_reading_mode($oldReadingMode);
+                }
+
+                if ($oldStage) {
+                    Versioned::set_stage($oldStage);
+                }
+
                 static::$isViewingPreview = false;
             }
 


### PR DESCRIPTION

Specifically on child pages where the parent is not published, likely due to calling getParent()

The shared draft preview flow in src/Controllers/ShareDraftController.php switches the reading mode to draft before rendering shared content, but it also needs to explicitly set the current Versioned stage to draft and restore the original stage afterwards. 


**Expected behaviour:**

Shared draft links should always render the current draft page.


**Actual behaviour:**

Sometimes the homepage is rendering as the preview instead of the draft content page.



## Issues

- https://github.com/silverstripe/silverstripe-sharedraftcontent/issues/312

## Pull request checklist
<!--
  PLEASE check each of these to ensure you have done everything you need to do!
  If there's something in this list you need help with, please ask so that we can assist you.
-->
- [ ] The target branch is correct
    - See [picking the right version](https://docs.silverstripe.org/en/contributing/code/#picking-the-right-version)
- [ ] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [ ] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [ ] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [ ] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [ ] This change is covered with tests (or tests aren't necessary for this change)
- [ ] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [ ] CI is green
